### PR TITLE
Updates to Pa11y Config and Frontend/Backend README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ tdrs-frontend/npm-debug.log*
 tdrs-frontend/yarn-debug.log*
 tdrs-frontend/yarn-error.log*
 tdrs-frontend/vars-frontend.yml
+tdrs-frontend/.env.local
+tdrs-frontend/pa11y-screenshots/*
 
 #BACKEND
 tdrs-backend/*/env_vars/*.env*

--- a/tdrs-frontend/.pa11yci.json
+++ b/tdrs-frontend/.pa11yci.json
@@ -1,15 +1,29 @@
 {
-  "standard": "WCAG2AAA",
-  "level": "error",
   "defaults": {
-    "timeout": 20000,
-    "wait": 2000,
-    "ignore": [],
-    "chromeLaunchConfig": {
-      "args": ["--no-sandbox"]
-    }
+    "timeout": 100000,
+    "threshold": 2,
+    "wait": 1000
   },
+  "level": "error",
+  "standard": "WCAG2AA",
+  "ignore": [
+      "notice",
+      "warning",
+      "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail",
+      "WCAG2AA.Principle3.Guideline3_2.3_2_2.H32.2"
+      ],
+  "viewport": {
+      "width": 1000,
+      "height": 1000 
+     },
   "urls": [
-    "http://localhost:3000/"
+    {
+      "url": "http://localhost:3000",
+      "screenCapture": "pa11y-screenshots/homepage.png"
+    },
+    {
+      "url": "http://localhost:3000/dashboard",
+      "screenCapture": "pa11y-screenshots/dashboard.png"      
+    }
   ]
 }

--- a/tdrs-frontend/README.md
+++ b/tdrs-frontend/README.md
@@ -1,67 +1,110 @@
-# TDRS Frontend
+# Frontend for TDP
 
-This project uses the U.S. Web Design System ([USWDS](https://designsystem.digital.gov/)) and in particular, [trussworks/react-uswds](https://github.com/trussworks/react-uswds)
+Frontend API Service for TDP. Deployed to Cloud.gov at https://tdp-frontend.app.cloud.gov/ . The project uses [USWDS](https://designsystem.digital.gov/) and in particular, [trussworks/react-uswds](https://github.com/trussworks/react-uswds)
 
-## To build for deployment
+# Prerequisites
 
-- From `TANF-app/tdrs-frontend` run
-  ```
-  docker build -t adamcaron/tdrs-frontend .
-  ```
-- If you wish to run the build distribution locally:
-  ```
-  docker run -it -p 3000:80 --rm adamcaron/tdrs-frontend:latest
-  ```
-- Push the image to the remote repository on hub.docker.com:
-  ```
-  docker push adamcaron/tdrs-frontend:latest
-  ```
+- [Docker](https://docs.docker.com/docker-for-mac/install/)  
+- [Login.gov Sandbox Account](https://idp.int.identitysandbox.gov/sign_up/enter_email)
+- [Cloud.gov Account](https://cloud.gov/)
+- [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+- [Yarn JavaScript Package Manager](https://classic.yarnpkg.com/en/docs/install/#mac-stable) 
 
-## To run locally
+# Contents
 
-- Clone this repository and
-  ```
-  cd TANF-app/tdrs-frontend
-  ```
-- Configure local environment variables with
+- [Local Development Options](#Local-Development-Options)
+- [Code Linting and Formatting](#Code-Linting-and-Formatting)
+- [Unit and Integration Testing](#Unit-and-Integration-Testing)
+- [Manual Cloud.gov Deployments](#Manual-Cloud.gov-Deployments)
+
+# Testing the local Frontend Service:
+
+  **Login is now dependent on the [tdrs-backend](../tdrs-backend/README.md) service. You will need a local instance of that application running.**
+
+
+### Local Development Options
+
+**Commands are to be executed from within the `tdrs-frontend` directory**
+
+1.) Create a `env.local` file with the following command:
   ```
   cp .env.local.example .env.local
   ```
-- Build the Docker image locally with
-  ```
-  docker build --target localdev -t adamcaron/tdrs-frontend:local .
-  ```
-- Run the app:
-  ```
-  docker run -it -p 3000:3000 -v $PWD/src/:/home/node/app/src --rm adamcaron/tdrs-frontend:local yarn start
-  ```
-
-Navigate to [localhost:3000](localhost:3000) and you should see the app.
+  - The `REACT_APP_BACKEND_URL` variable in this file points to the backend host. For local testing this value should default to the following :
+  
+   ```
+   http://localhost:8080/v1
+   ```
 
 
-**Login is now linked with the [tdrs-backend](../tdrs-backend/README.md) service. You will need a local instance of that application running**
+2.) Frontend project spin-up options: 
+
+- Option 1 (Using Yarn directly): We recommend using [NVM](https://github.com/nvm-sh/nvm)
+
+    ```bash
+    $ nvm install 12.18.3 # Install specific node version
+    $ yarn
+    $ yarn build
+    $ yarn start 
+    ```
+
+- Option 2 (Build and start via docker-compose):
+
+    ```bash
+    $ docker-compose up -d --build
+    ```
+    This will start one container named `tdrs-frontend_tdp-frontend` with port `3000`. Any changes made in `tdrs-frontend` folder will be picked up by docker automatically (no stop/run containers each time). 
 
 
+3.) With the project started, you can access the landing page via a web-browser ( we recommend `Chrome`) at the following URL:
+```
+http://localhost:3000
+```
 
-The `TANF-app/tdrs-frontend/src` directory is mounted into the container so changes to the source code, when saved, automatically update the contents of `/home/node/app/src` in the container. Restarting the container is not necessary during development and you should see changes update in the UI instantly.
+4.) This will redirect you to the `TDP Homepage` page with a button labeled `Sign in with Login.gov`.
 
-**Alternatively the app can be run with docker-compose:**
-- ```
-  docker-compose up --build
-  ```
+- Clicking this button will redirect you to the login.gov authentication page.
+-  You must agree to associate your account with the `TANF Prototype: Development` application.
+-  If you encounter any issues signing in, please ensure you are using a [Login.gov-Sandbox Account](https://idp.int.identitysandbox.gov/) and **NOT** your [Login.gov Account](login.gov).
 
+
+5.) Upon successful authentication with you will be redirected to the frontend dashboard (`/dashboard`) UI with an option to sign out.
+
+
+6.) Clicking the `Sign Out` button will log you out of the application and redirect you to the landing page,
+
+
+7.) Frontend project tear down options: 
+
+  - If using Option 1 or 3 from above:
+
+    ```
+     Kill the application running in your terminal.
+
+     MacOS Example: control+c
+    ```
+
+  - Option 2 (If you ran the application via docker-compose):
+
+    ```bash
+    $ docker-compose down
+    ```
+
+----
 ### Code Linting and Formatting
 
 The app is set up with [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/), and follows the [Airbnb Style Guide](https://github.com/airbnb/javascript).
 
 To run eslint locally:
-```
-yarn lint
+```bash
+$ yarn lint
 ```
 
 If you use [VSCode](https://code.visualstudio.com/) as an [IDE](https://en.wikipedia.org/wiki/Integrated_development_environment), it will be helpful to add the extensions, [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) and [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode). These make it possible to catch lint errors as they occur, and even auto-fix style errors (with Prettier).
 
-### Running Tests
+----
+
+### Unit and Integration Testing
 
 This project uses [Jest](https://jestjs.io/) for unit tests and [Cypress](https://www.cypress.io/) for end-to-end (e2e) tests.
 
@@ -69,27 +112,23 @@ This project uses [Jest](https://jestjs.io/) for unit tests and [Cypress](https:
 
 Jest provides an interactive test consolde that's helpful for development. After running the following commands, you will see options to run all the tests, run only failing tests, run specific tests, and more.
 
-Before running the subsequent commands, first:
-```
-cd TANF-app/tdrs-frontend
-```
 
-- To run unit tests locally:
+1.) To run unit tests locally:
+  ```bash
+  $ yarn test
   ```
-  yarn test
+2.) To run unit tests with code coverage report:
+  ```bash
+  $ yarn test:cov
   ```
-- To run unit tests with code coverage report:
-  ```
-  yarn test:cov
-  ```
-- To run unit tests as a CI environment would, which runs the tests once (without the interactive console):
-  ```
-  yarn test:ci
+3.) To run unit tests as a continuous integration environment would, which runs the tests once (without the interactive console):
+  ```bash
+  $ yarn test:ci
   ```
 
 After running either `test:cov` or `test:ci`, coverage details can be seen as HTML in the browser by running:
-```
-open coverage/lcov-report/index.html
+```bash
+$ open coverage/lcov-report/index.html
 ```
 
 In addition to [Jest's matchers](https://jestjs.io/docs/en/expect), this project uses [enzyme-matchers](https://github.com/FormidableLabs/enzyme-matchers) to simplify tests and make them more readable. Enzyme matchers is integrated with Jest using the [`jest-enzyme` package](https://github.com/FormidableLabs/enzyme-matchers/blob/master/packages/jest-enzyme/README.md#assertions) which provides many useful assertions for testing React components.
@@ -100,120 +139,54 @@ It is required to run the application locally for Cypress to run, since it actua
 Cypress requires that the application is running locally in order to perform its tests, since it navigates to the URL and performs tests on the rendered UI.
 - Run the app (see docs [to run locally](#to-run-locally))
 - Open the Cypress app:
-  ```
-  yarn cy:open
+  ```bash
+  $ yarn cy:open
   ```
 - The Cypress Test Runner immediately displays a list of Integration Tests. Click on one to run it, or run all tests.
 - Alternatively the tests can all be run from the command line without the interactive browser window:
-  ```
-  yarn cy:run
+  ```bash
+  $ yarn cy:run
   ```
 
 The [Cypress guides](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html#Add-a-test-file) are helpful.
 
 ----
 
-## Create React App Documentation
+### Manual Cloud.gov Deployments:
 
-_The following is the documentation for [Create React App](https://github.com/facebook/create-react-app). It is kept here as a baseline set of documentation for the foundation of the TDRS frontend. It is the default output of initializing the React app._
+Although CircleCi is [set up to auto deploy](https://github.com/raft-tech/TANF-app/blob/raft-tdp-main/.circleci/config.yml#L131) frontend and backend to Cloud.gov, if there is a need to do a manual deployment, the instructions below can be followed:
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-
-## Available Scripts
-
-In the project directory, you can run:
-
-### `yarn start`
-
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
-
-### `yarn test`
-
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `yarn build`
-
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `yarn eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `yarn build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
-
-
-## Cloud.gov Deployments:
-
-1.) Build and push a tagged docker image while on the the target github branch:
+1.) Build and push a tagged docker image while on the the target Github branch:
 
  (**Please note you need to be logged into docker for these operations**)
 
-`cd tdrs-frontend; docker build -t goraftdocker/tdp-frontend:devtest . -f docker/Dockerfile.dev`
+```
+docker build -t goraftdocker/tdp-frontend:devtest . -f Dockerfile.dev`
 
-`docker push goraftdocker/tdp-frontend:devtest`
+docker push goraftdocker/tdp-frontend:devtest
+```
 
 
 2.) Log into your cloud.gov account and set your space and organization:
 
-**ORG: The target deployment organization as defined in cloud.gov Applications**
+##### - **ORG: The target deployment organization as defined in cloud.gov Applications** 
 
-**SPACE: The target deployment space under the organization as defined in cloud.gov Applications**
-```
-cf login -a api.fr.cloud.gov --sso
-cf target -o <ORG> -s <SPACE>
+##### - **SPACE: The target deployment space under the organization as defined in cloud.gov Applications**
+```bash
+$ cf login -a api.fr.cloud.gov --sso
+$ cf target -o <ORG> -s <SPACE>
 ```
 
 3.) Push the image to Cloud.gov (  you will need to be in the same directory as`tdrs-frontend/manifest.yml`):
 
-( **The `--var` parameter ingests a value into the ((docker-backend)) environment variable in the manifest.yml**)
+( **The `--var` parameter ingests a value into the ``((docker-frontend))`` environment variable in the manifest.yml**)
 
-`cf push tdp-frontend --no-route -f manifest.yml --var docker-backend=goraftdockertdp-frontend:devtest`
+```bash
+ cf push tdp-frontend --no-route -f manifest.yml --var docker-frontend=goraftdocker/tdp-frontend:devtest
+```
 
 4.) It may be required to restage the application after deployment:
 
-`cf restage tdp-frontend`
+```bash
+$ cf restage tdp-frontend
+```

--- a/tdrs-frontend/package.json
+++ b/tdrs-frontend/package.json
@@ -39,7 +39,7 @@
     "test": "snyk test && react-scripts test",
     "test:cov": "react-scripts test --coverage --watchAll",
     "test:ci": "CI=1 react-scripts test --coverage",
-    "test:accessibility": "concurrently -k -s first 'yarn start:ci' 'wait-on http://localhost:3000/ && yarn pa11y-ci --config .pa11yci.json'",
+    "test:accessibility": "concurrently -k -s first 'yarn start:ci' 'wait-on http://localhost:3000/' && yarn pa11y-ci --config .pa11yci.json",
     "eject": "react-scripts eject",
     "lint": "eslint src/ && echo 'Lint complete.'"
   },


### PR DESCRIPTION
This PR does the following:

## Pa11y

- We updated the standards to `WCAG2AA`, updated the timeouts and thresholds

- We ran Pa11y on local TDP app, the one deployed on Cloud.gov https://tdp-frontend.app.cloud.gov/ , and google.com. local TDP app and Cloud.gov TDP app came back clean, however, google.com did not come back clean. This would show that the tests are running and returning accurate results.
```
➜  tdrs-frontend git:(fix-readme) ✗ yarn pa11y-ci --config .pa11yci.json                                                                                                                                                      (prod3/default)
yarn run v1.22.4
$ tdrs-frontend/node_modules/.bin/pa11y-ci --config .pa11yci.json
Running Pa11y on 5 URLs:
 > http://localhost:3000 - 0 errors (within threshold of 2)
 > http://localhost:3000/dashboard - 0 errors (within threshold of 2)
 > https://tdp-frontend.app.cloud.gov/ - 0 errors (within threshold of 2)
 > https://tdp-frontend.app.cloud.gov/dashboard - 0 errors (within threshold of 2)
 > https://google.com - 3 errors

Errors in https://google.com:

 • Presentational markup used that has become obsolete in HTML5.

   (html > body > center)

   <center><br clear="all" id="lgpd"><div ...</center>

 • Align attributes .

   (html > body > center > form > table > tbody > tr > td:nth-child(2))

   <td align="center" nowrap=""><input name="ie" value="ISO-885...</td>

 • Align attributes .

   (html > body > center > form > table > tbody > tr > td:nth-child(3))

   <td class="fl sblc" align="left" nowrap="" width="25%"><a href="/advanced_search?hl=en...</td>

✘ 4/5 URLs passed
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Frontend Readme

## Backend Readme