### PR TITLE
Add Contributors section to docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,3 +38,8 @@ Because this `/docs` folder migrated over from a project wiki, it has many terri
 + @cmajel
 + @Miatta18F
 + @rahearn
+
+Foundational work during the prototyping stage of this project was done by:
+
++ @timothy-spencer
++ Abbey Kos

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,3 +27,14 @@ This is not a place for...
 * Any Personally Identifiable Information (PII)
 * Any information about or from specific states, tribes, or territories
 * Any security or privacy related documentation
+
+# Contributors
+
+Because this `/docs` folder migrated over from a project wiki, it has many terrific contributors whose names you may not see reflected in the git history, including:
+
++ @SelenaJV
++ @lfrohlich
++ @lauraGgit
++ @cmajel
++ @Miatta18F
++ @rahearn


### PR DESCRIPTION
## Preview link

https://github.com/HHS/TANF-app/tree/ars/add-contributors-to-docs-readme/docs#contributors

## Notes 

Adding this before we remove the product wiki and finish the docs migration. 

## Issue link

https://github.com/raft-tech/TANF-app/issues/321