### PR TITLE
Draft: Clean up deploy script

### DIFF
--- a/deploy-cloudgov-docker.sh
+++ b/deploy-cloudgov-docker.sh
@@ -144,22 +144,6 @@ if [ "$1" = "setup" ] ; then  echo
 	    sleep 2
 	  fi
 	fi
-
-	# Set up backend:
-	if cf app $CGHOSTNAME_BACKEND >/dev/null 2>&1 ; then
-		echo $CGHOSTNAME_BACKEND app already set up
-	else
-	    update_backend
-		cf bind-service $CGHOSTNAME_BACKEND tdp-db
-		cf restage $CGHOSTNAME_BACKEND
-	fi
-
-	# Set up frontend:
-	if cf app $CGHOSTNAME_FRONTEND >/dev/null 2>&1 ; then
-		echo $CGHOSTNAME_FRONTEND app already set up
-	else
-	    update_frontend
-	fi
 fi
 
 # Generates and sets JWT cert and keys for new environment.

--- a/deploy-cloudgov-docker.sh
+++ b/deploy-cloudgov-docker.sh
@@ -64,7 +64,7 @@ echo CIRCLE_BRANCH=$CIRCLE_BRANCH
 # Helper function to check if a service exists.
 service_exists()
 {
-  cf service "$1" >/dev/null 2>&1
+	cf service "$1" >/dev/null 2>&1
 }
 
 
@@ -110,7 +110,7 @@ if [ $DEPLOY_STRATEGY = "rolling" ] ; then
 	update_backend 'rolling'
 	update_frontend 'rolling'
 else
-    update_backend
+	update_backend
 	update_frontend
 fi
 
@@ -119,36 +119,36 @@ fi
 # 3. Deploy the backend.
 # 4. Bind the backend to needed services.
 # 5. Deploy the frontend.
-if [ "$1" = "setup" ] ; then  echo
+if [ "$1" = "setup" ] ; then echo
 	# Create services (if needed):
 	if service_exists "tdp-app-deployer" ; then
-	  echo tdp-app-deployer already created
+		echo tdp-app-deployer already created
 	else
-	  cf create-service cloud-gov-service-account space-deployer tdp-app-keys
-	  cf create-service-key tdp-app-keys deployer
-	  echo "to get the CF_USERNAME and CF_PASSWORD, execute 'cf service-key tdp-app-keys deployer'"
+		cf create-service cloud-gov-service-account space-deployer tdp-app-keys
+		cf create-service-key tdp-app-keys deployer
+		echo "to get the CF_USERNAME and CF_PASSWORD, execute 'cf service-key tdp-app-keys deployer'"
 	fi
 
 	if service_exists "tdp-db" ; then
-	  echo tdp-db already created
+		echo tdp-db already created
 	else
-	  if [ $DEPLOY_ENV = "prod" ] ; then
-	    cf create-service aws-rds medium-psql-redundant tdp-db
+		if [ $DEPLOY_ENV = "prod" ] ; then
+			cf create-service aws-rds medium-psql-redundant tdp-db
 			cf bind-service $CGHOSTNAME_BACKEND tdp-db
 			cf restage $CGHOSTNAME_BACKEND
 
-		  echo sleeping until db is awake
-		  for i in 1 2 3 ; do
-		  	sleep 60
-		  	echo $i minutes...
-		  done
-	  else
-	    cf create-service aws-rds shared-psql tdp-db
+			echo sleeping until db is awake
+			for i in 1 2 3 ; do
+				sleep 60
+				echo $i minutes...
+			done
+		else
+			cf create-service aws-rds shared-psql tdp-db
 			cf bind-service $CGHOSTNAME_BACKEND tdp-db
 			cf restage $CGHOSTNAME_BACKEND
 
-	    sleep 2
-	  fi
+			sleep 2
+		fi
 	fi
 fi
 

--- a/deploy-cloudgov-docker.sh
+++ b/deploy-cloudgov-docker.sh
@@ -54,8 +54,8 @@ echo CIRCLE_BRANCH=$CIRCLE_BRANCH
 # For an example rolling deploy:
 # See .circleci/config.yml, which calls this script as part of the deploy process.
 
-# Example staging deploy:
-# ./deploy-cloudgov-docker.sh setup test tdp-backend-staging tdp-frontend-staging lfrohlich/tdp-backend lfrohlich/tdp-frontend staging
+# Example vendor staging deploy:
+# ./deploy-cloudgov-docker.sh setup test tdp-backend-vendor-staging tdp-frontend-vendor-staging lfrohlich/tdp-backend:raft-tdp-main lfrohlich/tdp-frontend:raft-tdp-main raft-tdp-main
 
 # Remember, the script assumes that the user is logged in to Cloud.gov via the Cloud Foundry CLI.
 

--- a/deploy-cloudgov-docker.sh
+++ b/deploy-cloudgov-docker.sh
@@ -95,10 +95,10 @@ update_backend()
 		cf push $CGHOSTNAME_BACKEND --no-route -f tdrs-backend/manifest.yml --var docker-backend=$DOCKER_IMAGE_BACKEND
 		# Set up JWT key if needed:
 		if cf e $CGHOSTNAME_BACKEND | grep -q JWT_KEY ; then
-		   echo jwt cert already created
+			echo "jwt cert already created."
 		else
-		   generate_jwt_cert
-	   fi
+			echo "jwt cert needs to be created and set: see generate_jwt_cert."
+		fi
 	fi
 	cf map-route $CGHOSTNAME_BACKEND app.cloud.gov --hostname "$CGHOSTNAME_BACKEND"
 }

--- a/deploy-cloudgov-docker.sh
+++ b/deploy-cloudgov-docker.sh
@@ -97,7 +97,7 @@ update_backend()
 		if cf e $CGHOSTNAME_BACKEND | grep -q JWT_KEY ; then
 			echo "jwt cert already created."
 		else
-			echo "jwt cert needs to be created and set: see generate_jwt_cert."
+			echo "jwt cert needs to be created and set: see generate_jwt_cert.sh in the /scripts folder."
 		fi
 	fi
 	cf map-route $CGHOSTNAME_BACKEND app.cloud.gov --hostname "$CGHOSTNAME_BACKEND"
@@ -151,27 +151,6 @@ if [ "$1" = "setup" ] ; then echo
 		fi
 	fi
 fi
-
-# Generates and sets JWT cert and keys for new environment.
-# Called as part of new environment setup.
-generate_jwt_cert()
-{
-	echo "regenerating JWT cert/key"
-	yes 'XX' | openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -sha256
-	cf set-env $CGHOSTNAME_BACKEND JWT_CERT "$(cat cert.pem)"
-	cf set-env $CGHOSTNAME_BACKEND JWT_KEY "$(cat key.pem)"
-
-	# Let user of this script know that they will need fto set an OIDC_RP_CLIENT_ID.
-	if cf e $CGHOSTNAME_BACKEND | grep -q OIDC_RP_CLIENT_ID ; then
-		echo OIDC_RP_CLIENT_ID already set up
-	else
-		echo "once you have gotten your client ID set up with login.gov, you will need to set the OIDC_RP_CLIENT_ID to the proper value"
-		echo "you can do this by running: cf set-env tdp-backend OIDC_RP_CLIENT_ID 'your_client_id'"
-		echo "login.gov will need this cert when you are creating the app:"
-		cat cert.pem
-		cf set-env $CGHOSTNAME_BACKEND OIDC_RP_CLIENT_ID "XXX"
-	fi
-}
 
 # Tell people where to go:
 echo

--- a/deploy-cloudgov-docker.sh
+++ b/deploy-cloudgov-docker.sh
@@ -57,6 +57,9 @@ echo CIRCLE_BRANCH=$CIRCLE_BRANCH
 # Example staging deploy:
 # ./deploy-cloudgov-docker.sh setup test tdp-backend-staging tdp-frontend-staging lfrohlich/tdp-backend lfrohlich/tdp-frontend staging
 
+# Remember, the script assumes that the user is logged in to Cloud.gov via the Cloud Foundry CLI.
+
+# SCRIPT HELPERS AND TASKS
 
 # Helper function to check if a service exists.
 service_exists()

--- a/scripts/generate_jwt_cert.sh
+++ b/scripts/generate_jwt_cert.sh
@@ -1,0 +1,18 @@
+# Generates and sets JWT cert and keys for new environment.
+# Called as part of new environment setup.
+
+echo "regenerating JWT cert/key"
+yes 'XX' | openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -sha256
+cf set-env $CGHOSTNAME_BACKEND JWT_CERT "$(cat cert.pem)"
+cf set-env $CGHOSTNAME_BACKEND JWT_KEY "$(cat key.pem)"
+
+# Let user of this script know that they will need fto set an OIDC_RP_CLIENT_ID.
+if cf e $CGHOSTNAME_BACKEND | grep -q OIDC_RP_CLIENT_ID ; then
+  echo OIDC_RP_CLIENT_ID already set up
+else
+  echo "once you have gotten your client ID set up with login.gov, you will need to set the OIDC_RP_CLIENT_ID to the proper value"
+  echo "you can do this by running: cf set-env tdp-backend OIDC_RP_CLIENT_ID 'your_client_id'"
+  echo "login.gov will need this cert when you are creating the app:"
+  cat cert.pem
+  cf set-env $CGHOSTNAME_BACKEND OIDC_RP_CLIENT_ID "XXX"
+fi


### PR DESCRIPTION
# User Story

This PR is part of https://github.com/raft-tech/TANF-app/issues/521, "As a developer, I want a staging site and I want to know how to deploy to it."

This specifically addresses the step: "Use the opportunity to improve deploy-related documentation along the way."
 
# What does this change?

This PR should have no effect on the deploy process itself besides improving the experience of developers using this script as part of the deploy process. 

Most of these changes are code comment changes -- adding or updating code comments to make this script easier to read and easier to use for developers. 

There are two exceptions:

1. One exception relates to the helper function, `generate_jwt_cert`. This function is called when deploying a new application that does not have a `JWT_KEY` environment variable set. When I ran the script to deploy a staging part as part of 521, this line caused the script to error out, as `generate_jwt_cert` was not defined in the Cloud.gov environment. This PR removes the call to `generate_jwt_cert` since it causes an error when run in the Cloud.gov environment and seems intended more for local use following a deploy.
2. The other removes lines of code that I believe are never run — see more in the inline code comments below.

## TO TEST

_To test developer experience improvement:_

+ [ ] Read through code comments in prior version of the deploy script versus new version of the deploy script -- is the new version clearer, does it provide more context and more relevant information?

_To test no impact on the deploy process:_
 
1. Merge this PR. 
2. Pull this PR into the vendor repo. 
3. Run an automated deploy process from the vendor repo.
4. There should be no impact at all on the deploy process from this change. 
5. If there is (not likely), revert. 

