### PR TITLE
Draft: Add vendor staging site to deploy flow 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,44 +106,24 @@ jobs:
       - run:
           name: deploy to cloud.gov
           command: |
-            # If we do not specify a space, then deploy to the branch that we are on.
-            # Also map certain branches to spaces.
-            # This lets you have dev/staging/main branches that automatically go to the right place.
             export DOCKER_IMAGE_BACKEND="lfrohlich/tdp-backend:$CIRCLE_BRANCH"
             export DOCKER_IMAGE_FRONTEND="lfrohlich/tdp-frontend:$CIRCLE_BRANCH"
-            if [ "$CIRCLE_BRANCH" == "main" ] ; then
-              export CF_SPACE="tanf-prod"
-              export CF_USERNAME="$CF_USERNAME_PROD"
-              export CF_PASSWORD="$CF_PASSWORD_PROD"
-              export CGHOSTNAME_BACKEND="$CGHOSTNAME_BACKEND_PROD"
-              export CGHOSTNAME_FRONTEND="$CGHOSTNAME_FRONTEND_PROD"
-            elif [ "$CIRCLE_BRANCH" == "staging" ] ; then
-              export CF_SPACE="tanf-staging"
-              export CF_USERNAME="$CF_USERNAME_STAGING"
-              export CF_PASSWORD="$CF_PASSWORD_STAGING"
-              export CGHOSTNAME_BACKEND="$CGHOSTNAME_BACKEND_STAGING"
-              export CGHOSTNAME_FRONTEND="$CGHOSTNAME_FRONTEND_STAGING"
-            elif [ "$CIRCLE_BRANCH" == "dev" ] ; then
-              export CF_SPACE="tanf-dev"
-              export CF_USERNAME="$CF_USERNAME_DEV"
-              export CF_PASSWORD="$CF_PASSWORD_DEV"
+            
+            # Both environments we have set up are in dev Cloud.gov Space right now.
+            export CF_SPACE="tanf-dev"
+            export CF_USERNAME="$CF_USERNAME_DEV"
+            export CF_PASSWORD="$CF_PASSWORD_DEV"
+
+            if [ "$CIRCLE_BRANCH" == "raft-tdp-main" || "$CIRCLE_BRANCH" == "raft-review" ] ; then
               export CGHOSTNAME_BACKEND="$CGHOSTNAME_BACKEND_DEV"
               export CGHOSTNAME_FRONTEND="$CGHOSTNAME_FRONTEND_DEV"
-            elif [ "$CIRCLE_BRANCH" == "raft-tdp-main" ] ; then
-              export CF_SPACE="tanf-dev"
-              export CF_USERNAME="$CF_USERNAME_DEV"
-              export CF_PASSWORD="$CF_PASSWORD_DEV"
-              export CGHOSTNAME_BACKEND="$CGHOSTNAME_BACKEND_DEV"
-              export CGHOSTNAME_FRONTEND="$CGHOSTNAME_FRONTEND_DEV"
-            elif [ "$CIRCLE_BRANCH" == "raft-review" ] ; then
-              export CF_SPACE="tanf-dev"
-              export CF_USERNAME="$CF_USERNAME_DEV"
-              export CF_PASSWORD="$CF_PASSWORD_DEV"
-              export CGHOSTNAME_BACKEND="$CGHOSTNAME_BACKEND_DEV"
-              export CGHOSTNAME_FRONTEND="$CGHOSTNAME_FRONTEND_DEV"
+            elif [ "$CIRCLE_BRANCH" == "raft-staging" ] ; then
+              export CGHOSTNAME_BACKEND="tdp-backend-vendor-staging"
+              export CGHOSTNAME_FRONTEND="tdp-frontend-vendor-staging"
             else
               export CF_SPACE="$CIRCLE_BRANCH"
             fi
+
             if [ -z "$CF_ORG" ] ; then
               echo CF_ORG not set, aborting
               exit 1
@@ -167,3 +147,4 @@ workflows:
               only:
                 - raft-tdp-main
                 - raft-review
+                - raft-staging


### PR DESCRIPTION
# User Story

This PR is part of https://github.com/raft-tech/TANF-app/issues/521, "As a developer, I want a staging site and I want to know how to deploy to it."

This specifically addresses the step: "Update CI/CD pipeline to deploy code automatically to staging."
 
# What does this change?

* Code merged to the `raft-staging` branch will automatically deploy to the vendor staging site via CircleCI.
* No additional ENV variables should be required in the vendor CI to enable this, since the vendor staging site will exist in the same Space on Cloud.gov as the existing site (see 008-deployment-flow.md for more).

## TO TEST

1. Merge this PR into the HHS repo. 
2. Pull this PR into the vendor repo. 
3. Cut a new PR into the `raft-staging` branch on the vendor repo and merge.
4. Watch the `deploy` step in CircleCI after merge.
5. Visit the staging site URL and confirm successful deploy. 