### PR TITLE
Draft: Update README with vendor staging info; set ADR 008 to "accepted"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ On each git push and merge, a comprehensive list of automated checks are run: Un
 
 The application is continuously deployed to the dev, staging, or prod environments based on the git branch the code is merged in. The configuration for different branches is maintained in [`.circleci/config.yml`](https://github.com/HHS/TANF-app/blob/main/.circleci/config.yml#L107).
 
-See Architecture Decision Record 008 - Deployment Flow - for more.
+See [Architecture Decision Record 008 - Deployment Flow](docs/Architecture\ Decision\ Record/008-deployment-flow.md) - for more.
 
 The application is deployed to the following environments:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ On each git push and merge, a comprehensive list of automated checks are run: Un
 
 The application is continuously deployed to the dev, staging, or prod environments based on the git branch the code is merged in. The configuration for different branches is maintained in [`.circleci/config.yml`](https://github.com/HHS/TANF-app/blob/main/.circleci/config.yml#L107).
 
-See [Architecture Decision Record 008 - Deployment Flow](docs/Architecture Decision Record/008-deployment-flow.md) - for more.
+See [Architecture Decision Record 008 - Deployment Flow](docs/Architecture%20Decision%20Record/008-deployment-flow.md) - for more.
 
 The application is deployed to the following environments:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ On each git push and merge, a comprehensive list of automated checks are run: Un
 
 The application is continuously deployed to the dev, staging, or prod environments based on the git branch the code is merged in. The configuration for different branches is maintained in [`.circleci/config.yml`](https://github.com/HHS/TANF-app/blob/main/.circleci/config.yml#L107).
 
-See [Architecture Decision Record 008 - Deployment Flow](docs/Architecture\ Decision\ Record/008-deployment-flow.md) - for more.
+See [Architecture Decision Record 008 - Deployment Flow](docs/Architecture Decision Record/008-deployment-flow.md) - for more.
 
 The application is deployed to the following environments:
 

--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ On each git push and merge, a comprehensive list of automated checks are run: Un
 
 ### Continuous Deployment
 
-The application is continuously deployed to the dev, staging, or prod environments based on the git branch the code is merged in. The configuration for different branches is maintained in [`.circleci/config.yml`](https://github.com/HHS/TANF-app/blob/main/.circleci/config.yml#L107). The application is deployed to the following environments:
+The application is continuously deployed to the dev, staging, or prod environments based on the git branch the code is merged in. The configuration for different branches is maintained in [`.circleci/config.yml`](https://github.com/HHS/TANF-app/blob/main/.circleci/config.yml#L107).
+
+See Architecture Decision Record 008 - Deployment Flow - for more.
+
+The application is deployed to the following environments:
 
 Environment | URL | Git Branch
 ------------|----|-------------
-Development | https://tdp-frontend.app.cloud.gov/ | [`raft-tdp-main`](https://github.com/raft-tech/TANF-app) in Raft fork
-Staging | TBD | [`main`](https://github.com/HHS/TANF-app) in HHS
-Production | TBD | `production` in HHS
-
-
-
-
-
+Development | https://tdp-frontend.app.cloud.gov/ | `raft-tdp-main` in [Raft fork](https://github.com/raft-tech/TANF-app)
+Vendor staging | https://tdp-frontend-vendor-staging.app.cloud.gov/ | `raft-staging` in [Raft fork](https://github.com/raft-tech/TANF-app)
+Gov staging | TBD | TBD
+Production | TBD | TBD

--- a/docs/Architecture Decision Record/008-deployment-flow.md
+++ b/docs/Architecture Decision Record/008-deployment-flow.md
@@ -3,7 +3,7 @@ Date: 2021-01-27
 
 ## Status
 
-Proposed.
+Accepted.
 
 ## Context
 


### PR DESCRIPTION
# User Story

This PR is part of https://github.com/raft-tech/TANF-app/issues/521, "As a developer, I want a staging site and I want to know how to deploy to it."

# README preview link

https://github.com/HHS/TANF-app/tree/ars/update-docs-for-521#continuous-deployment
 
# What does this change?

* Updates README with link and branch for vendor staging site. 

## TO TEST

* Check content for clarity 
* Check to see if any references are incorrect or need to be updated 
* Check links