### PR TITLE
Allow for correct logout behavior in staging env

### DIFF
--- a/tdrs-frontend/Dockerfile.dev
+++ b/tdrs-frontend/Dockerfile.dev
@@ -7,7 +7,7 @@ WORKDIR /home/node/app
 COPY --chown=node:node package.json yarn.lock ./
 USER node
 RUN yarn install && yarn cache clean
-RUN touch .env.production && echo "REACT_APP_BACKEND_URL=https://tdp-backend.app.cloud.gov/v1" >> .env.production
+RUN touch .env.production
 RUN echo "REACT_APP_TIMEOUT_TIME=1200000" >> .env.production
 RUN echo "REACT_APP_LOGOUT_TIME=180000" >> .env.production
 RUN echo "REACT_APP_DEBOUNCE_TIME=30000" >> .env.production


### PR DESCRIPTION
## Context 

The current code hard-codes REACT_APP_BACKEND_URL to point to the dev site. As a result, when a user logs out of the vendor staging site, they are redirected to the dev site homepage instead of the vendor staging site homepage.

## What does this change?

After merging this change, we'll want to set REACT_APP_BACKEND_URL values for the vendor staging site and dev site using the CF CLI or the Cloud.gov website.

After merging this change, we'll be able to set the correct REACT_APP_BACKEND_URL for each site without needing to worry about the value being overwritten on the next deploy.

## How to test?

After deploy, test logout redirect behavior on vendor staging site.

## Other notes

Deploy script should mention the need to set REACT_APP_BACKEND_URL on the frontend.
