### PR TITLE
Revert "Allow for correct logout behavior in staging env"

### DIFF
--- a/tdrs-frontend/Dockerfile.dev
+++ b/tdrs-frontend/Dockerfile.dev
@@ -7,7 +7,7 @@ WORKDIR /home/node/app
 COPY --chown=node:node package.json yarn.lock ./
 USER node
 RUN yarn install && yarn cache clean
-RUN touch .env.production
+RUN touch .env.production && echo "REACT_APP_BACKEND_URL=https://tdp-backend.app.cloud.gov/v1" >> .env.production
 RUN echo "REACT_APP_TIMEOUT_TIME=1200000" >> .env.production
 RUN echo "REACT_APP_LOGOUT_TIME=180000" >> .env.production
 RUN echo "REACT_APP_DEBOUNCE_TIME=30000" >> .env.production


### PR DESCRIPTION
### This pull request changes...

Reverts #184. #184 was not the correct solution for allowing correct logout behavior in staging. 

@carltonsmith and I assumed that we could set ENV on the frontend apps by setting ENV variables in Cloud.gov; that was not correct. 

Right now the changed lines in this Dockerfile represent the accurate (and only) way ENV is set on the frontend. ENV is set during the build process. 

We'll reverse this change to un-break the dev site; @jtwillis92 will carry forward allowing for correct logout behavior in https://github.com/raft-tech/TANF-app/issues/673.