### PR TITLE
update buildpacks

### DIFF
--- a/tdrs-backend/manifest.buildpack.yml
+++ b/tdrs-backend/manifest.buildpack.yml
@@ -8,5 +8,5 @@ applications:
     REDIS_URI: redis://localhost:6379
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
-  - https://github.com/cloudfoundry/python-buildpack.git#v1.7.55
+  - https://github.com/cloudfoundry/python-buildpack.git#v1.8.3
   command: "./gunicorn_start.sh"

--- a/tdrs-frontend/manifest.buildpack.yml
+++ b/tdrs-frontend/manifest.buildpack.yml
@@ -3,7 +3,7 @@ version: 1
 applications:
 - name: tdp-frontend
   buildpacks:
-    - https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.39
+    - https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.45
   memory: 32M
   instances: 1
   disk_quota: 256M


### PR DESCRIPTION
## Summary of Changes
Pull request closes #2183

Update buildpacks
* Nginx
   * 1.1.45
      * Add nginx 1.23.2, remove nginx 1.23.1 for stack(s) cflinuxfs3
      * Add nginx 1.22.1, remove nginx 1.22.0 for stack(s) cflinuxfs3
   * 1.1.44
      * Update libbuildpack
   * 1.1.43
      * Update libbuildpack
   * 1.1.42
      * Add nginx 1.23.1, remove nginx 1.23.0 for stack(s) cflinuxfs3
   * 1.1.41
      * Add nginx 1.23.0, remove nginx 1.21.6 for stack(s) cflinuxfs3
      * Deprecate Nginx 1.21.x (replaced by the new mainline 1.23.x)
   * 1.1.40
      * Enable debug logging for all currently supported nginx versions
      * Add dynatrace integration
   * 1.1.39
      * Deprecate nginx 1.20.2 (End of life)
      * Add nginx 1.22.0 for stack(s) cflinuxfs3
      * Add openresty 1.21.4.1 for stack(s) cflinuxfs3
      * Remove estimated deprecation dates. They were causing confusion to the users
* Python
   * 1.8.3
      * Add python 3.11.0
for stack(s) cflinuxfs3, cflinuxfs4
   * 1.8.2
      * Add python 3.8.15, remove python 3.8.13 for stack(s) cflinuxfs3, cflinuxfs4 (https://www.pivotaltracker.com/story/show/183514400)
      * Add python 3.9.15, remove python 3.9.13 for stack(s) cflinuxfs4, cflinuxfs3 (https://www.pivotaltracker.com/story/show/183514701)
      * Add python 3.10.8, remove python 3.10.6 for stack(s) cflinuxfs3, cflinuxfs4
      * Add python 3.7.15, remove python 3.7.13 for stack(s) cflinuxfs4, cflinuxfs3
      * Add pip 22.3.1, remove pip 22.2.2 for stack(s) cflinuxfs4, cflinuxfs3
      * Add setuptools 65.5.1, remove setuptools 65.4.0 for stack(s) cflinuxfs4, cflinuxfs3
      * Add pipenv 2022.11.5, remove pipenv 2022.9.24 for stack(s) cflinuxfs4, cflinuxfs3
      * Distinguish Vendored and Unvendored installs in logs
      * Log used 'pip install' command before executing it for debugging
      * Print pip's version when using python's pip module. To be able to debug problems when using pip it's handy to know which version of pip is actually being used
   * 1.8.1
      * Add pipenv 2022.9.24, remove pipenv 2022.9.21 for stack(s) cflinuxfs3, cflinuxfs4
      * Add setuptools 65.4.0, remove setuptools 65.3.0 for stack(s) cflinuxfs4, cflinuxfs3
      * Remove deprecated functions in Go code(https://github.com/cloudfoundry/python-buildpack/pull/608)
   * 1.8.0
      * Add support for cflinuxfs4 stack.
      * Add pipenv 2022.9.21, remove pipenv 2022.9.8 for stack(s) cflinuxfs3, cflinuxfs4
   * 1.7.59
      * Add python 3.7.14, remove python 3.7.12 for stack(s) cflinuxfs3 (https://www.pivotaltracker.com/story/show/183201709)
      * Add python 3.8.14, remove python 3.8.12 for stack(s) cflinuxfs3 (https://www.pivotaltracker.com/story/show/183209169)
      * Add python 3.9.14, remove python 3.9.12 for stack(s) cflinuxfs3 (https://www.pivotaltracker.com/story/show/183209172)
      * Add python 3.10.7, remove python 3.10.5 for stack(s) cflinuxfs3 (https://www.pivotaltracker.com/story/show/183186088) 
      * Add pipenv 2022.9.8, remove pipenv 2022.8.19 for stack(s) cflinuxfs3 supply: remove pre-installing mercurial (https://github.com/cloudfoundry/python-buildpack/pull/576)
   * 1.7.58
      * Set CFLAGS when building. Fix for Python.h: No such file or directory error on native extensions.
      * Add setuptools 65.3.0, remove setuptools 63.4. for stack(s) cflinuxfs3 (https://www.pivotaltracker.com/story/show/183070646) (https://www.pivotaltracker.com/story/show/182956247)
      * Add pipenv 2022.8.19, remove pipenv 2022.8.5 for stack(s) cflinuxfs3 (https://www.pivotaltracker.com/story/show/183033182)
   * 1.7.57
      * Add python 3.10.6, remove python 3.10.4 for stack(s) cflinuxfs3
      * Add pip 22.2.2, remove pip 22.1.2 for stack(s) cflinuxfs3
      * Add pipenv 2022.8.5, remove pipenv 2022.7.4 for stack(s) cflinuxfs3
      * Add setuptools 63.4.2, remove setuptools 63.1.0 for stack(s) cflinuxfs3
      * Scrub multiple ways of describing index-url from requiremnts.txt when using vendored installs (https://github.com/cloudfoundry/python-buildpack/pull/544). See https://github.com/pypa/pip/issues/11276 for the upstream problem.
   * 1.7.56
      * Add pipenv 2022.7.4, remove pipenv 2022.6.7 for stack(s) cflinuxfs3
      * Add setuptools 63.1.0, remove setuptools 62.3.3 for stack(s) cflinuxfs3

## How to Test
1. Deploy to a Cloud.gov environment.
1. Open http://localhost:3000/ and sign in.
1. Do some tests.

## Deliverables
_More details on how deliverables herein are assessed included [here](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverables)._

### [Deliverable 1: Accepted Features](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-1-Accepted-Features)

Checklist of ACs:
+ [ ] [**_insert ACs here_**]
+ [ ] **`lfrohlich`** and/or **`adpennington`**  confirmed that ACs are met.

### [Deliverable 2: Tested Code](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-2-Tested-Code)

+ Are all areas of code introduced in this PR meaningfully tested?
  + [ ] If this PR introduces backend code changes, are they meaningfully tested?
  + [ ] If this PR introduces frontend code changes, are they meaningfully tested?
+ Are code coverage minimums met?
  + [ ] Frontend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)
  + [ ] Backend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)

### [Deliverable 3: Properly Styled Code](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-3-Properly-Styled-Code)

+ [ ] Are backend code style checks passing on CircleCI?
+ [ ] Are frontend code style checks passing on CircleCI?
+ [ ] Are code maintainability principles being followed?

### [Deliverable 4: Accessible](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-4-Accessibility)

+ [ ] Does this PR complete the epic? 
+ [ ] Are links included to any other gov-approved PRs associated with epic?
+ [ ] Does PR include documentation for Raft's a11y review? 
+ [ ] Did automated and manual testing with `iamjolly` and `ttran-hub` using Accessibility Insights reveal any errors introduced in this PR?


### [Deliverable 5: Deployed](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-5-Deployed)

+ [ ] Was the code successfully deployed via automated CircleCI process to development on Cloud.gov?

### [Deliverable 6: Documented](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-6-Code-documentation)

+ [ ] Does this PR provide background for why coding decisions were made?
+ [ ] If this PR introduces backend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces frontend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces dependencies, are their licenses documented?
+ [ ] Can reviewer explain and take ownership of these elements presented in this code review?

### [Deliverable 7: Secure](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-7-Secure)

+ [ ] Does the OWASP Scan pass on CircleCI?
+ [ ] Do manual code review and manual testing detect any new security issues?
+ [ ] If new issues detected, is investigation and/or remediation plan documented? 

### [Deliverable 8: User Research](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-8-User-Research)

Research product(s) clearly articulate(s):
+ [ ] the purpose of the research
+ [ ] methods used to conduct the research 
+ [ ] who participated in the research
+ [ ] what was tested and how
+ [ ] impact of research on TDP
+ [ ] (_if applicable_) final design mockups produced for TDP development 


