### PR TITLE
Changes for fully local development

### DIFF
--- a/tdrs-backend/.env.example
+++ b/tdrs-backend/.env.example
@@ -2,6 +2,8 @@
 # Copy this file to `.env` and replace variables as needed
 # 
 
+DEVELOPMENT=1
+
 # ##
 # Required environment variables
 # These must be defined or the application will encounter fatal errors

--- a/tdrs-backend/tdpservice/data_files/views.py
+++ b/tdrs-backend/tdpservice/data_files/views.py
@@ -54,6 +54,7 @@ class DataFileViewSet(ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         """Override create to upload in case of successful scan."""
+        logger.debug(f"{self.__class__.__name__}: {request}")
         response = super().create(request, *args, **kwargs)
 
         # only if file is passed the virus scan and created successfully will we perform side-effects:
@@ -61,6 +62,7 @@ class DataFileViewSet(ModelViewSet):
         # * Upload to ACF-TITAN
         # * Send email to user
 
+        logger.debug(f"{self.__class__.__name__}: status: {response.status_code}")
         if response.status_code == status.HTTP_201_CREATED or response.status_code == status.HTTP_200_OK:
             user = request.user
             data_file_id = response.data.get('id')
@@ -109,6 +111,7 @@ class DataFileViewSet(ModelViewSet):
             if len(recipients) > 0:
                 send_data_submitted_email(list(recipients), data_file, email_context, subject)
 
+        logger.debug(f"{self.__class__.__name__}: return val: {response}")
         return response
 
     def get_s3_versioning_id(self, file_name, prefix):

--- a/tdrs-backend/tdpservice/settings/common.py
+++ b/tdrs-backend/tdpservice/settings/common.py
@@ -293,6 +293,7 @@ class Common(Configuration):
         "DEFAULT_RENDERER_CLASSES": DEFAULT_RENDERER_CLASSES,
         "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
         "DEFAULT_AUTHENTICATION_CLASSES": (
+            "tdpservice.users.authentication.DevAuthentication",
             "tdpservice.users.authentication.CustomAuthentication",
             "rest_framework.authentication.SessionAuthentication",
             "rest_framework.authentication.TokenAuthentication",

--- a/tdrs-backend/tdpservice/users/authentication.py
+++ b/tdrs-backend/tdpservice/users/authentication.py
@@ -4,7 +4,22 @@ from django.contrib.auth import get_user_model
 
 from rest_framework.authentication import BaseAuthentication
 import logging
+import os
 logger = logging.getLogger(__name__)
+
+class DevAuthentication(BaseAuthentication):
+    def authenticate(self, request):
+        if not os.environ.get('DEVELOPMENT'):
+            return None
+        logging.debug(f"{self.__class__.__name__}: {request} ; {request.data}")
+        requser = request.data.get("user")
+        reqname = requser if requser and requser != "undefined" else "dev@test.com"
+        User = get_user_model()
+        authuser = User.objects.get(username=reqname)
+        if authuser and requser == "undefined":
+            request.data["user"] = authuser.id
+        return (User.objects.get(username=reqname), True)
+
 
 class CustomAuthentication(BaseAuthentication):
     """Define authentication and get user functions for custom authentication."""

--- a/tdrs-backend/tdpservice/users/management/commands/generate_dev_user.py
+++ b/tdrs-backend/tdpservice/users/management/commands/generate_dev_user.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management import BaseCommand
+
+User = get_user_model()
+
+email = "dev@test.com"
+pswd = "pass"
+first = "Jon"
+last = "Tester"
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        try:
+            user = User.objects.get(username=email)
+            print(f"Found {vars(user)}")
+        except User.DoesNotExist:
+            group = Group.objects.get(name="Developer")
+            user = User.objects.create(username=email,
+                                       email=email,
+                                       password=pswd,
+                                       first_name=first,
+                                       last_name=last,
+                                       account_approval_status="Approved")
+            user.groups.add(group)
+            print(f"Created {vars(user)}")
+    

--- a/tdrs-backend/tdpservice/users/permissions.py
+++ b/tdrs-backend/tdpservice/users/permissions.py
@@ -8,6 +8,9 @@ from django.apps import apps
 from collections import ChainMap
 from copy import deepcopy
 from typing import List, Optional, TYPE_CHECKING
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -126,6 +129,7 @@ class IsApprovedPermission(permissions.DjangoModelPermissions):
 
     def has_permission(self, request, view):
         """Return True if the user has been assigned a group and is approved."""
+        logging.debug(f"{self.__class__.__name__}: {request} ; {view}")
         return (request.user.groups.first() is not None and
                 request.user.account_approval_status == AccountApprovalStatusChoices.APPROVED)
 
@@ -160,6 +164,8 @@ class DataFilePermissions(DjangoModelCRUDPermissions):
         Data Analyst will only have permission to files within their STT and a
         Regional Manager will only have permission to files within their region.
         """
+        logging.debug(f"{self.__class__.__name__}: {request} ; {view}")
+
         # Checks for existence of `data_files.view_datafile` Permission
         has_permission = super().has_permission(request, view)
 

--- a/tdrs-frontend/.env
+++ b/tdrs-frontend/.env
@@ -4,6 +4,8 @@
 # WARNING: This file is checked in to source control, do NOT store any secrets in this file
 #
 
+DEVELOPMENT=1
+
 # The hostname behind the tdrs-backend Django app
 REACT_APP_BACKEND_HOST=http://127.0.0.1:8080
 

--- a/tdrs-frontend/docker-compose.yml
+++ b/tdrs-frontend/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 8090:8090
     networks:
-      - local
+      - default
     volumes:
       - ./reports:/zap/wrk/:rw
       - ../scripts/zap-hook.py:/zap/scripts/zap-hook.py:ro
@@ -21,7 +21,6 @@ services:
       - 3000:80
       - 8080:8080
     networks:
-      - local
       - default
     volumes:
       - ./:/home/node/app
@@ -42,9 +41,6 @@ services:
       && nginx -g 'daemon off;'"
 
 networks:
-  local:
-    driver: bridge
-
   default:
     external:
       name: external-net

--- a/tdrs-frontend/src/actions/auth.js
+++ b/tdrs-frontend/src/actions/auth.js
@@ -40,6 +40,9 @@ export const SET_MOCK_LOGIN_STATE = 'SET_MOCK_LOGIN_STATE'
  */
 
 export const fetchAuth = () => async (dispatch) => {
+  if (process.env.DEVELOPMENT) {
+    return 0
+  }
   dispatch({ type: FETCH_AUTH })
   try {
     const URL = `${process.env.REACT_APP_BACKEND_URL}/auth_check`

--- a/tdrs-frontend/src/configureStore.js
+++ b/tdrs-frontend/src/configureStore.js
@@ -4,6 +4,7 @@ import { createBrowserHistory } from 'history'
 import thunkMiddleware from 'redux-thunk'
 import loggerMiddleware from './middleware/logger'
 import createRootReducer from './reducers'
+import { permissions } from './components/Header/developer_permissions'
 
 export const history = createBrowserHistory()
 
@@ -13,9 +14,29 @@ export const history = createBrowserHistory()
 export default function configureStore(preloadedState) {
   const middlewares = [thunkMiddleware, loggerMiddleware]
   const composedEnhancers = composeWithDevTools(applyMiddleware(...middlewares))
+  const devState = {
+    router: { location: { pathname: '/profile' } },
+    auth: {
+      user: {
+        email: 'dev@test.com',
+        first_name: 'Jon',
+        last_name: 'Tester',
+        roles: [{ id: 1, name: 'Developer', permissions }],
+        access_request: true,
+        account_approval_status: 'Approved',
+        stt: {
+          id: 31,
+          type: 'state',
+          code: 'NJ',
+          name: 'New Jersey',
+        },
+      },
+      authenticated: true,
+    },
+  }
   const store = createStore(
     createRootReducer(history),
-    preloadedState,
+    process.env.DEVELOPMENT ? devState : preloadedState,
     composedEnhancers
   )
   return store


### PR DESCRIPTION
 - Enables direct frontend/backend communication sans Login.gov/Cloud.gov
 - Drives off new DEVELOPMENT env var
 - Pre-configures and disables frontend auth functionality
 - Testing based on new dev user
   - Install via web: ./manage.py generate_dev_user


## How to Test
Start frontend and backend locally.
Create the dev user in a web container shell: ./manage.py generate_dev_user
Open http://localhost:3000/data-files in browser.
Submit a data file normally.
Verify with logs and postgres DB query.
