### PR TITLE
Hotfix: Pipenv Version not Specified

### DIFF
--- a/scripts/apply-database-config.sh
+++ b/scripts/apply-database-config.sh
@@ -20,7 +20,7 @@ sudo apt install -y libpq-dev python3-dev
 
 python -m venv ./env
 source ./env/bin/activate
-pip install --upgrade pip pipenv
+pip install --upgrade pip pipenv==2026.0.3
 pipenv install --dev --system --deploy
 echo "Done."
 

--- a/tdrs-backend/Dockerfile.base
+++ b/tdrs-backend/Dockerfile.base
@@ -20,7 +20,7 @@ RUN apt-get update && \
         python3-dev \
         curl \
         ca-certificates && \
-    pip install --no-cache-dir --upgrade pip pipenv && \
+    pip install --no-cache-dir --upgrade pip pipenv==2026.0.3 && \
     # If we can remove the '--dev' we will save 200MB. However, so much depends on it that it is easier to keep it for now.
     pipenv install --dev --system --deploy && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary of Changes
- Cherry picked commit from develop that forces the pipeline to use a compatible version of pipenv
