### PR TITLE
Hotfix v4.23.3 - fix settings.DEBUG inversion

### DIFF
--- a/tdrs-backend/tdpservice/security/views.py
+++ b/tdrs-backend/tdpservice/security/views.py
@@ -109,7 +109,7 @@ class SecurityEventTokenView(APIView):
                 algorithms=["RS256"],
                 audience=settings.LOGIN_GOV_SET_AUDIENCE,
                 options={
-                    "verify_signature": settings.DEBUG,
+                    "verify_signature": not settings.DEBUG,
                     "verify_exp": True,
                 },
             )


### PR DESCRIPTION
* invert `settings.DEBUG` so that the setting is applied correctly

Resolves [GHSA-w5f9-6g83-v6mc](https://github.com/raft-tech/TANF-app/security/advisories/GHSA-w5f9-6g83-v6mc)